### PR TITLE
docs: expand README and auto-init DOM host on mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,83 @@
-OWT Language (Draft)
+# OWT
 
-This repo contains an initial, typed implementation of the OWT toolchain:
+**Make it happen.**
 
-- Compiler: `packages/owt-compiler` (parses `.owt` and outputs TypeScript)
-- Parser/AST: `packages/owt-parser`, `packages/owt-ast`
-- Runtime: `packages/owt-runtime` (mounting + types)
-- Vite Plugin: `packages/vite-plugin-owt`
-- Feature Docs: `features/*`
- - Language Spec: `spec.md`
+OWT is an experimental, typed UI language that keeps developer experience front and center. The goal is a smart, clean way to build reactive interfaces:
 
-Usage (local dev)
-- Install deps: `pnpm i`
-- In your Vite app `vite.config.ts`:
+- No `useState` or hooks ceremony.
+- No `$` prefixes or template syntax quirks.
+- No magic list macros – just a readable `for` loop.
+
+Write components with plain TypeScript expressions and HTML-like markup. The compiler turns `.owt` files into TypeScript and a tiny runtime handles fine‑grained DOM updates.
+
+## Why OWT?
+
+Existing approaches either lean on heavy frameworks or rely on template-specific syntax. OWT takes a different path:
+
+### Plain TSX
+TSX lets you author UI in TypeScript, but you still manage reactivity and DOM updates manually. OWT adds declarative state and reactivity while keeping the authoring experience close to TSX.
+
+### React
+React popularized components and a virtual DOM but introduces hooks, `useState`, and reconciliation overhead. OWT compiles components to direct DOM operations, so updating state is as simple as assigning to a `var`.
+
+### Svelte
+Svelte removes the virtual DOM but adds magic like `$:` labels and `$` store prefixes. OWT aims for the same compiled efficiency without special syntax—just TypeScript and a few keywords.
+
+Together these ideas aim to be a game changer for typed UI development.
+
+## Features
+
+- **State with `var` and `val`** – `var` declares reactive writable state, while `val` defines derived read-only values.
+- **Typed components** – Component signatures are real TypeScript functions, giving you autocompletion and static checking.
+- **Control flow** – Use `if/else` and `for … empty` blocks, including numeric ranges like `1..10`, to render lists and branches.
+- **Slots** – Components expose named insertion points for children.
+- **Scoped styles** – Inline `<style>` blocks are scoped to the component.
+- **Async blocks** – Await Promises directly within markup.
+- **Tiny runtime** – Compiled output targets a minimal DOM runtime with fine‑grained updates.
+
+See [`features/`](features) and the full [language specification](spec.md) for details and current limitations.
+
+## Quick Start
+
+Install dependencies and add the Vite plugin:
+
+```bash
+pnpm install
+```
 
 ```ts
-import { defineConfig } from 'vite'
-import owt from 'vite-plugin-owt'
+// vite.config.ts
+import { defineConfig } from 'vite';
+import owt from '@owt/vite';
 
 export default defineConfig({
   plugins: [owt()],
-})
+});
 ```
 
-Example
-- Create `App.owt`:
+Create a component:
 
 ```owt
 export component App(props: { title: string }) {
-  <div>
-    <h1>{props.title}</h1>
-    <button onClick={() => console.log('Clicked')}>Click</button>
-  </div>
+  <h1>{props.title}</h1>
 }
 ```
 
-- Mount it:
+Mount it in your app:
 
 ```ts
-import { mount } from 'owt-runtime'
-import { App } from './App.owt'
+import { mount } from 'owt/dom';
+import { App } from './App.owt';
 
-mount(App, { props: { title: 'Hello' }, target: document.getElementById('root')! })
+mount(App, { props: { title: 'Hello' }, target: document.getElementById('root')! });
 ```
 
-Notes
-- Fine-grained updates are implemented for common cases: text nodes bound to simple `var`/`val`, selected attributes (e.g. `value`, `textContent`, boolean attributes), and control blocks. Event handlers detect changed `var`s and notify only the affected bindings.
-- See `features/*` and `spec.md` for current behavior and plans.
+The `mount` helper automatically initializes the DOM host—no extra setup required.
+
+## Examples
+
+The [`examples/`](examples) directory contains runnable projects. Start with [`basic`](examples/basic) or explore the more complete [`todo-app`](examples/todo-app).
+
+## Status
+
+OWT is a work in progress. Expect breaking changes while the language and tooling evolve.

--- a/examples/basic/src/main.ts
+++ b/examples/basic/src/main.ts
@@ -1,4 +1,4 @@
-import { mount } from 'owt';
+import { mount } from 'owt/dom';
 import { App } from './App.owt';
 
 mount(App, {

--- a/examples/todo-app/src/main.ts
+++ b/examples/todo-app/src/main.ts
@@ -1,8 +1,5 @@
-import { mount, initDomHost } from 'owt/dom';
+import { mount } from 'owt/dom';
 import { App } from './App.owt';
 import './styles.css';
-
-// Initialize DOM host
-initDomHost();
 
 mount(App, { props: {}, target: document.getElementById('app')! });

--- a/packages/owt/src/dom.ts
+++ b/packages/owt/src/dom.ts
@@ -1,13 +1,23 @@
-export { mount } from '@owt/runtime';
-export { setDevLogger, devLog } from '@owt/runtime';
-export { domHost, setHost } from '@owt/runtime';
-
-// Import locally for use in functions
-import { setHost as _setHost, domHost as _domHost } from '@owt/runtime';
+import {
+  mount as runtimeMount,
+  setDevLogger,
+  devLog,
+  domHost,
+  setHost,
+  type ComponentFn,
+} from '@owt/runtime';
 
 // Initialize DOM host
 export function initDomHost() {
-  _setHost(_domHost);
+  setHost(domHost);
 }
+
+// Mount components and ensure the DOM host is ready
+export function mount<P>(Component: ComponentFn<P>, options: { props?: P; target: HTMLElement }) {
+  initDomHost();
+  return runtimeMount(Component, options);
+}
+
+export { setDevLogger, devLog, domHost, setHost };
 
 


### PR DESCRIPTION
## Summary
- auto-init DOM host when mounting via `owt/dom`
- update examples and Quick Start to mount without `initDomHost`

## Testing
- `pnpm run lint` *(fails: Cannot find package '@typescript-eslint/parser')*
- `pnpm test` *(fails: Test Files 2 failed | Tests 5 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c74a0730708330bd4315341fc7f3bd